### PR TITLE
Make Jenkinsfiles use the indigo-dc shared library

### DIFF
--- a/{{ cookiecutter.repo_name }}/DEEP-OC-{{ cookiecutter.repo_name }}/Jenkinsfile
+++ b/{{ cookiecutter.repo_name }}/DEEP-OC-{{ cookiecutter.repo_name }}/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
 
     environment {
-        dockerhub_repo = "deephdc/test-DEEP-OC-{{ cookiecutter.repo_name }}"
+        dockerhub_repo = "deephdc/DEEP-OC-{{ cookiecutter.repo_name }}"
     }
 
     stages {

--- a/{{ cookiecutter.repo_name }}/DEEP-OC-{{ cookiecutter.repo_name }}/Jenkinsfile
+++ b/{{ cookiecutter.repo_name }}/DEEP-OC-{{ cookiecutter.repo_name }}/Jenkinsfile
@@ -3,11 +3,12 @@
 @Library(['github.com/indigo-dc/jenkins-pipeline-library']) _
 
 pipeline {
+    agent {
+        label 'docker-build'
+    }
+
     stages {
         stage('DockerHub delivery') {
-            agent {
-                label 'docker-build'
-            }
             steps{
                 checkout scm
                 script {

--- a/{{ cookiecutter.repo_name }}/DEEP-OC-{{ cookiecutter.repo_name }}/Jenkinsfile
+++ b/{{ cookiecutter.repo_name }}/DEEP-OC-{{ cookiecutter.repo_name }}/Jenkinsfile
@@ -7,12 +7,16 @@ pipeline {
         label 'docker-build'
     }
 
+    environment {
+        dockerhub_repo = "deephdc/test-DEEP-OC-{{ cookiecutter.repo_name }}"
+    }
+
     stages {
         stage('DockerHub delivery') {
             steps{
                 checkout scm
                 script {
-                    image_id = DockerBuild(dockerhub_repo, env.BRANCH_NAME)
+                    image_id = DockerBuild("${env.dockerhub_repo}, env.BRANCH_NAME)
                 }
             }
             post {

--- a/{{ cookiecutter.repo_name }}/DEEP-OC-{{ cookiecutter.repo_name }}/Jenkinsfile
+++ b/{{ cookiecutter.repo_name }}/DEEP-OC-{{ cookiecutter.repo_name }}/Jenkinsfile
@@ -1,0 +1,30 @@
+#!/usr/bin/groovy
+
+Library(['github.com/indigo-dc/jenkins-pipeline-library']) _
+
+pipeline {
+    stages {
+        stage('DockerHub delivery') {
+            agent {
+                label 'docker-build'
+            }
+            steps{
+                checkout scm
+                script {
+                    image_id = DockerBuild(dockerhub_repo, env.BRANCH_NAME)
+                }
+            }
+            post {
+                success {
+                    DockerPush(image_id)
+                }
+                failure {
+                    DockerClean()
+                }
+                always {
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/{{ cookiecutter.repo_name }}/DEEP-OC-{{ cookiecutter.repo_name }}/Jenkinsfile
+++ b/{{ cookiecutter.repo_name }}/DEEP-OC-{{ cookiecutter.repo_name }}/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/groovy
 
-Library(['github.com/indigo-dc/jenkins-pipeline-library']) _
+@Library(['github.com/indigo-dc/jenkins-pipeline-library']) _
 
 pipeline {
     stages {

--- a/{{ cookiecutter.repo_name }}/Jenkinsfile
+++ b/{{ cookiecutter.repo_name }}/Jenkinsfile
@@ -1,96 +1,47 @@
-node {
-  def githubcredentials = '_(CHANGE!)_' // github credentials as stored in Jenkins
-  def dockerhubuser = '{{ cookiecutter.dockerhub_user }}'
-  def dockerhubcredentials = '_(CHANGE!)_' // dockerhub credentials as stored in Jenkins
-  def appName = '{{ cookiecutter.repo_name }}'
-  def mainVer = '{{ cookiecutter.app_version }}'
-  def imageTagBase = "${appName}:${env.BRANCH_NAME}-${mainVer}.${env.BUILD_NUMBER}"
-  def imageTagExtension = ''    // e.g. '-gpu'
-  def imageTag = "${dockerhubuser}/deep-oc-${imageTagBase}${imageTagExtension}"
-  def imageTagLatest = "${dockerhubuser}/deep-oc-${appName}"
-  
-  try {
-      stage ('Clone repositories') {
-          dir("${appName}") {
-              checkout([$class: 'GitSCM', branches: [[name: '*/master']],
-                  credentialsId: "${githubcredentials}",
-                  userRemoteConfigs: [[url: "http://github.com/{{ cookiecutter.github_user }}/${appName}.git"]]])
-          }
+#!/usr/bin/groovy
 
-          dir("DEEP-OC-${appName}") {
-              checkout([$class: 'GitSCM', branches: [[name: '*/master']],
-                  credentialsId: "${githubcredentials}",
-                  userRemoteConfigs: [[url: "http://github.com/{{ cookiecutter.github_user }}/DEEP-OC-${appName}.git"]]])
-          }
-      }
+Library(['github.com/indigo-dc/jenkins-pipeline-library']) _
 
-      stage ('Build test image and run tests') {
-          dir("${appName}") {
-              def imageTagTest = "${imageTagBase}-tests"
-              sh("nvidia-docker build -t ${imageTagTest} -f docker/Dockerfile.tests .")
-              sh("docker run ${imageTagTest} ./run_pylint.sh >pylint.log || exit 0")        
-              warnings canComputeNew: false, canResolveRelativePaths: false, categoriesPattern: '', defaultEncoding: '', excludePattern: '', healthy: '', includePattern: '', messagesPattern: '', parserConfigurations: [[parserName: 'PyLint', pattern: '**/pylint.log']], unHealthy: ''
+pipeline {
+    parameters {
+        string(name: 'appName',
+               defaultValue: "{{ cookiecutter.repo_name }}",
+               description: 'Application name from DEEP-OC repository')
+    }
+    stages {
+        stage('Fetch the repository') {
+            steps {
+                checkout scm
+            }
+        }
+	
+        stage('Style analysis: PEP8') {
+            steps {
+                ToxEnvRun('pep8')
+            }
+            post {
+                always {
+                    WarningsReport('Pep8')
+                }
+            }
+        }
 
-              echo "Here should be more tests for ${imageTagTest}"
-              // delete test docker image from Jenkins site
-              sh("docker rmi --force ${imageTagTest}")
-          }
-      }
+        stage('Style analysis: Pylint') {
+            steps {
+                ToxEnvRun('pylint')
+            }
+            post {
+                always {
+                    WarningsReport('Pylint')
+                }
+            }
+        }
 
-
-      stage ('Build and Push docker image to registry') {
-          dir("DEEP-OC-${appName}") { 
-              sh("nvidia-docker build -t ${imageTag} -t ${imageTagLatest} .")
-              withCredentials([usernamePassword(credentialsId: "${dockerhubcredentials}", usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                  sh '''
-                     docker login -u "$USERNAME" -p "$PASSWORD"
-                     '''
-              }
-              sh("docker push ${imageTag}")
-              sh("docker push ${imageTagLatest}")  
-          }    
-      }
-
-      stage('Deploy Application') {
-      }
-
-      stage('Post Deployment') {
-          // delete docker image from Jenkins site
-          sh("docker rmi ${imageTag}")
-          sh("docker rmi ${imageTagLatest}")
-      }
-  } catch (e) {
-    // If there was an exception thrown, the build failed
-    currentBuild.result = "FAILED"
-    throw e
-  } finally {
-    // Success or failure, always send notifications
-    notifyBuild()
-  }
-}
-
-def notifyBuild() {
-    String buildStatus =  currentBuild.result
-    // build status of null means successful
-    buildStatus =  buildStatus ?: 'SUCCESS'
-  
-    // One can re-define default values
-    def subject = "${buildStatus}: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'"
-    def summary = "${subject} (${env.BUILD_URL})"
-    def details = """<p>STARTED: Job '${env.JOB_NAME} - build # ${env.BUILD_NUMBER}' on $env.NODE_NAME.</p>
-      <p>TERMINATED with: ${buildStatus}
-      <p>Check console output at "<a href="${env.BUILD_URL}">${env.BUILD_URL}</a>"</p>"""
-
-
-    emailext (
-        subject: '${DEFAULT_SUBJECT}', //subject,
-        mimeType: 'text/html',
-        body: details,                 //'${DEFAULT_CONTENT}'
-        attachLog: true,
-        compressLog: true,
-        attachmentsPattern: '**/pylint.log',
-        recipientProviders: [[$class: 'CulpritsRecipientProvider'],
-                            [$class: 'DevelopersRecipientProvider'],
-                            [$class: 'RequesterRecipientProvider']]
-    )
+        stage("Re-build DEEP-OC-${params.appName} Docker image") {
+            steps {
+                job_location = "Pipeline-as-code/DEEP-OC-org/DEEP-OC-${params.appName}"
+                JenkinsBuildJob($job_location)
+            }
+        }
+    }
 }

--- a/{{ cookiecutter.repo_name }}/Jenkinsfile
+++ b/{{ cookiecutter.repo_name }}/Jenkinsfile
@@ -8,7 +8,12 @@ pipeline {
     }
 
     environment {
-        job_location = "Pipeline-as-code/DEEP-OC-org/DEEP-OC-{{ cookiecutter.repo_name }}"
+        author_name = "{{ cookiecutter.author_name }}"
+        author_email = "{{ cookiecutter.author_email }}"
+        app_name = "{{ cookiecutter.repo_name }}"
+        job_location = "Pipeline-as-code/DEEP-OC-org/\
+                        DEEP-OC-{{ cookiecutter.repo_name }}"
+        job_result_url = ''
     }
 
     stages {
@@ -42,7 +47,31 @@ pipeline {
 
         stage("Re-build DEEP-OC-{{ cookiecutter.repo_name }} Docker image") {
             steps {
-                JenkinsBuildJob("${env.job_location}")
+                script {
+                    def job_result = JenkinsBuildJob("${env.job_location}")
+                    def job_result_url = job_result.absoluteUrl
+                }
+            }
+        }
+
+        stage("Email notification") {
+            steps {
+                script {
+                    def build_status =  currentBuild.result
+                    build_status =  build_status ?: 'SUCCESS'
+                    def subject = "New ${app_name} build in Jenkins@DEEP:\
+                                   ${build_status}: Job '${env.JOB_NAME}\
+                                   [${env.BUILD_NUMBER}]'"
+                    def body = "Dear ${author_name},\nA new build of\
+                                '${app_name}' DEEP application is available in\
+                                Jenkins at:\n\n\t${env.BUILD_URL}\n\nterminated\
+                                with '${build_status}' status.\n\nCheck console\
+                                output at:\n\n\t${env.BUILD_URL}/console\n\n\
+                                and resultant Docker image rebuilding job at:\
+                                \n\n\t${job_result_url}\n\nDEEP Jenkins CI\
+                                service"
+                    EmailSend(subject, body, "${author_email}")
+                }
             }
         }
     }

--- a/{{ cookiecutter.repo_name }}/Jenkinsfile
+++ b/{{ cookiecutter.repo_name }}/Jenkinsfile
@@ -3,11 +3,6 @@
 Library(['github.com/indigo-dc/jenkins-pipeline-library']) _
 
 pipeline {
-    parameters {
-        string(name: 'appName',
-               defaultValue: "{{ cookiecutter.repo_name }}",
-               description: 'Application name from DEEP-OC repository')
-    }
     stages {
         stage('Fetch the repository') {
             steps {
@@ -37,9 +32,9 @@ pipeline {
             }
         }
 
-        stage("Re-build DEEP-OC-${params.appName} Docker image") {
+        stage("Re-build DEEP-OC-{{ cookiecutter.repo_name }} Docker image") {
             steps {
-                job_location = "Pipeline-as-code/DEEP-OC-org/DEEP-OC-${params.appName}"
+                job_location = "Pipeline-as-code/DEEP-OC-org/DEEP-OC-{{ cookiecutter.repo_name }}"
                 JenkinsBuildJob($job_location)
             }
         }

--- a/{{ cookiecutter.repo_name }}/Jenkinsfile
+++ b/{{ cookiecutter.repo_name }}/Jenkinsfile
@@ -3,9 +3,14 @@
 @Library(['github.com/indigo-dc/jenkins-pipeline-library']) _
 
 pipeline {
+    agent {
+        label 'python'
+    }
+
     environment {
         job_location = "Pipeline-as-code/DEEP-OC-org/DEEP-OC-{{ cookiecutter.repo_name }}"
     }
+
     stages {
         stage('Fetch the repository') {
             steps {

--- a/{{ cookiecutter.repo_name }}/Jenkinsfile
+++ b/{{ cookiecutter.repo_name }}/Jenkinsfile
@@ -3,6 +3,9 @@
 @Library(['github.com/indigo-dc/jenkins-pipeline-library']) _
 
 pipeline {
+    environment {
+        job_location = "Pipeline-as-code/DEEP-OC-org/DEEP-OC-{{ cookiecutter.repo_name }}"
+    }
     stages {
         stage('Fetch the repository') {
             steps {
@@ -34,8 +37,7 @@ pipeline {
 
         stage("Re-build DEEP-OC-{{ cookiecutter.repo_name }} Docker image") {
             steps {
-                job_location = "Pipeline-as-code/DEEP-OC-org/DEEP-OC-{{ cookiecutter.repo_name }}"
-                JenkinsBuildJob($job_location)
+                JenkinsBuildJob("${env.job_location}")
             }
         }
     }

--- a/{{ cookiecutter.repo_name }}/Jenkinsfile
+++ b/{{ cookiecutter.repo_name }}/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/groovy
 
-Library(['github.com/indigo-dc/jenkins-pipeline-library']) _
+@Library(['github.com/indigo-dc/jenkins-pipeline-library']) _
 
 pipeline {
     stages {

--- a/{{ cookiecutter.repo_name }}/test-requirements.txt
+++ b/{{ cookiecutter.repo_name }}/test-requirements.txt
@@ -1,0 +1,2 @@
+flake8
+pylint

--- a/{{ cookiecutter.repo_name }}/tox.ini
+++ b/{{ cookiecutter.repo_name }}/tox.ini
@@ -37,4 +37,4 @@ builtins = _
 exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build
 
 [testenv:pylint]
-commands = pylint $(find . -maxdepth 4 -name "*.py") --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}"
+commands = pylint $(find . -maxdepth 4 -name "*.py")

--- a/{{ cookiecutter.repo_name }}/tox.ini
+++ b/{{ cookiecutter.repo_name }}/tox.ini
@@ -1,3 +1,40 @@
+[tox]
+minversion = 1.6
+envlist = py27,pep8
+skipsdist = True
+
+[testenv]
+usedevelop = True
+basepython = python3
+whitelist_externals =
+  find
+install_command = pip install -U {opts} {packages}
+setenv =
+   VIRTUAL_ENV={envdir}
+   LC_ALL=en_US.utf-8
+   OS_STDOUT_CAPTURE=1
+   OS_STDERR_CAPTURE=1
+   OS_TEST_TIMEOUT=160
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
+commands =
+    find . -type f -name "*.pyc" -delete
+
+[testenv:venv]
+commands = {posargs}
+
+[testenv:pep8]
+envdir = {toxworkdir}/shared
+commands =
+  flake8
+
 [flake8]
-max-line-length = 79
-max-complexity = 10
+# H803 skipped on purpose per list discussion.
+# E123, E125 skipped as they are invalid PEP-8.
+show-source = True
+ignore = E123,E125,H803,H405
+builtins = _
+exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build
+
+[testenv:pylint]
+commands = pylint $(find . -maxdepth 4 -name "*.py") --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}"


### PR DESCRIPTION
### Summary:
#### Jenkinsfile has been splitted in two: one for the main project and a specific one for DEEP-OC
- Logic seems to follow this path. Otherwise, we would need an additional step of cloning DEEP-OC repo (with a sh 'git clone ..' command) rather than using the more straightforward 'checkout scm' statement.
- Jenkinsfile@main-project triggers Jenkinsfile@DEEP-OC by referring to the job name in Jenkins
`job_location = Pipeline-as-code/DEEP-OC-org/DEEP-OC-{{ cookiecutter.repo_name }}`
- Jenkinsfile@DEEP-OC might substitute the automated build already configured. Thus additional checks can be done at this level (i.e. Dockerfile syntax, ..). 
- New DEEP-OC repos can be automatically detected by the "GitHub organization" job type in Jenkins, filtering repository names starting with 'DEEP-OC-*'
#### Uses credentials defined at Jenkins 
- No need of passing creds as parameters 
- This might remove the need of asking for DockerHub login in cookiecutter execution (not done in this PR)
#### Style checks
- PEP8 and Pylint through Tox environments ('pep8' and 'pylint').
- Test tools are installed in `test-requirements.txt` file, triggered by `tox` command.
